### PR TITLE
BI-8184, BI-8255 - Update consumer to use internal api key

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ type Config struct {
 	UpsertURL                 string      `env:"UPSERT_URL"                          flag:"upsert-url"                          flagDesc:"Url for upserting a company"`
 	RetryThrottleRate         int         `env:"RETRY_THROTTLE_RATE_SECONDS"         flag:"retry-throttle-rate-seconds"         flagDesc:"Retry throttle rate seconds"`
 	MaxRetryAttempts          int         `env:"MAXIMUM_RETRY_ATTEMPTS"              flag:"max-retry-attempts"                  flagDesc:"Maximum retry attempts"`
-	CHSAPIKey                 string      `env:"CHS_API_KEY"                         flag:"chs-api-key"                         flagDesc:"API key to call api's through eric"`
+	CHSAPIKey                 string      `env:"CHS_INTERNAL_API_KEY"                flag:"chs-api-key"                         flagDesc:"API key to call api's through eric"`
 }
 
 var cfg *Config


### PR DESCRIPTION
With the changes required for authorisation and authentication, the request to upsert a document will need to be made by an api key with internal privileges.

Resolves: BI-8184, BI-8255